### PR TITLE
Refactor configuration handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0d720b8683f8dd83c65155f0530560cba68cd2bf395f6513a483caee57ff7f4"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a340f241d2ceed1deb47ae36c4144b2707ec7dd0b649f894cb39bb595986324"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c41b3b7352feb3211a0d743dc5700a4e3b60f51bd2b368892d1e0f9a95f44b"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dunce"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,6 +138,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -147,7 +200,9 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 name = "mqp"
 version = "0.1.0"
 dependencies = [
+ "dunce",
  "serde",
+ "serde_with",
  "serde_yaml",
  "thiserror",
  "url",
@@ -220,6 +275,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+
+[[package]]
 name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,6 +301,29 @@ version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_with"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1e6ec4d8950e5b1e894eac0d360742f3b1407a6078a604a731c4b3f49cefbc"
+dependencies = [
+ "rustversion",
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12e47be9471c72889ebafb5e14d5ff930d89ae7a67bbdb5f8abb564f845a927e"
+dependencies = [
+ "darling",
  "proc-macro2",
  "quote",
  "syn",

--- a/PROPOSAL.md
+++ b/PROPOSAL.md
@@ -155,11 +155,17 @@ however it is *not* optional when installed into the ``pkgdb`` directory.
 This does not support the glob syntax, all files must be declared explicitly.
 
 
-## repositories.yml
+## MQPackage.yml
 
-This file is used to tell the installer what repositories a particular target
-directory wants to pull packages from. It must exist at the root of the target
-directory, and it is a simple yaml file that looks like:
+TODO: Is ``MQPackage.yml`` at the root the best filename here? I originally had
+      ``repositories.yml`` but it created odd sounding names when you talked
+      about the ``repositories`` key within it. I also thought about
+      ``config.yml`` or something similiar to that as well, but I was worried
+      that it would be confusing to people when that was specific to MQPackage.
+
+This file is used to configure the installer so that it is able to use the
+correct settings for a particular target directory. It must exist at the root
+of the target directory. It is a yaml file with a schema like:
 
 ```yaml
 repositories:

--- a/PROPOSAL.md
+++ b/PROPOSAL.md
@@ -155,13 +155,7 @@ however it is *not* optional when installed into the ``pkgdb`` directory.
 This does not support the glob syntax, all files must be declared explicitly.
 
 
-## MQPackage.yml
-
-TODO: Is ``MQPackage.yml`` at the root the best filename here? I originally had
-      ``repositories.yml`` but it created odd sounding names when you talked
-      about the ``repositories`` key within it. I also thought about
-      ``config.yml`` or something similiar to that as well, but I was worried
-      that it would be confusing to people when that was specific to MQPackage.
+## mqpkg.yml
 
 This file is used to configure the installer so that it is able to use the
 correct settings for a particular target directory. It must exist at the root
@@ -317,7 +311,7 @@ generate that.
 ### What does workflow look like for an end user?
 
 The end user will need to create the target directory, which will need to contain a
-``repositories.yml``file at the *root* of the target directory. The installer can then
+``mqpkg.yml``file at the *root* of the target directory. The installer can then
 be invoked on the command line using something like (cli name tbd):
 
 ```
@@ -370,7 +364,7 @@ an empty package that just contains dependencies on everything that is "shipped"
 with VV itself.
 
 A single .zip file containing everything could still be produced, it would just
-contain the ``repositories.yml`` file and ``pkgdb`` directory in addition to what
+contain the ``mqpkg.yml`` file and ``pkgdb`` directory in addition to what
 it already ships.
 
 Since under the covers, VV becomes just a meta package, that means all of the
@@ -392,7 +386,7 @@ there's two strategies that could be employed:
    same files.
 2. You could make another repository that contains all of the non compile specific
    packages, and have the common pattern to have like a ``live.json`` and ``all.json``
-   repositories that are bot hadded to the ``repositories.yml``.
+   repositories that are both added to the ``mqpkg.yml``.
 
 
 ### How are Paywalled packages handled?
@@ -408,7 +402,7 @@ strategies that can be used to implement them:
 
 2. Generate a repository for each paywalled package, and make it also paywalled
    (or not, you could still leave it open). Then when a user wants to add paywalled
-   content, they have to first add a new line to their ``repositories.yml``, then
+   content, they have to first add a new line to their ``mqpkg.yml``, then
    after that everything functions as expected.
 
 

--- a/mqp-cli/src/main.rs
+++ b/mqp-cli/src/main.rs
@@ -5,6 +5,8 @@
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 
+use mqp::Config;
+
 #[derive(Parser, Debug)]
 #[clap(version)]
 struct Cli {
@@ -25,7 +27,7 @@ enum Commands {
 fn main() -> Result<()> {
     let cli = Cli::parse();
     let _config = match cli.target {
-        Some(target) => mqp::Config::load(&target)
+        Some(target) => Config::load(&target)
             .with_context(|| format!("Invalid target directory '{}'", target))?,
         None => {
             let cur = std::env::current_dir()?;

--- a/mqp/Cargo.toml
+++ b/mqp/Cargo.toml
@@ -4,7 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+dunce = "1.0"
 serde = { version = "1.0", features = ["derive"] }
+serde_with = "1.12.0"
 serde_yaml = "0.8"
 thiserror = "1.0"
 url = { version = "2", features = ["serde"] }

--- a/mqp/src/lib.rs
+++ b/mqp/src/lib.rs
@@ -9,18 +9,18 @@ use serde::Deserialize;
 use thiserror::Error;
 use url::Url;
 
-const REPOSITORY_FILENAME: &str = "repositories.yml";
+const CONFIG_FILENAME: &str = "MQPackage.yml";
 
 #[derive(Error, Debug)]
 pub enum MQPackageError {
-    #[error("no repository configuration file")]
-    NoRepositoryConfig {
+    #[error("no configuration file")]
+    NoConfig {
         #[from]
         source: std::io::Error,
     },
 
-    #[error("invalid repository configuration")]
-    InvalidRepositoryConfig {
+    #[error("invalid configuration")]
+    InvalidConfig {
         #[from]
         source: serde_yaml::Error,
     },
@@ -56,8 +56,8 @@ impl Config {
         P: Into<PathBuf>,
     {
         let path = path.into();
-        let repofile = File::open(path.join(REPOSITORY_FILENAME))
-            .map_err(|source| MQPackageError::NoRepositoryConfig { source })?;
+        let repofile = File::open(path.join(CONFIG_FILENAME))
+            .map_err(|source| MQPackageError::NoConfig { source })?;
         let repos: Repository = serde_yaml::from_reader(repofile)?;
 
         Ok(Config {
@@ -72,7 +72,7 @@ impl Config {
     {
         let mut path = path.into();
         let target = loop {
-            path.push(REPOSITORY_FILENAME);
+            path.push(CONFIG_FILENAME);
             if path.is_file() {
                 assert!(path.pop());
                 break path;

--- a/mqp/src/lib.rs
+++ b/mqp/src/lib.rs
@@ -11,7 +11,7 @@ use serde_with::{serde_as, DisplayFromStr, PickFirst};
 use thiserror::Error;
 use url::Url;
 
-const CONFIG_FILENAME: &str = "MQPackage.yml";
+const CONFIG_FILENAME: &str = "mqpkg.yml";
 
 #[derive(Error, Debug)]
 pub enum MQPackageError {

--- a/mqp/src/lib.rs
+++ b/mqp/src/lib.rs
@@ -4,8 +4,10 @@
 
 use std::fs::File;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 
 use serde::Deserialize;
+use serde_with::{serde_as, DisplayFromStr, PickFirst};
 use thiserror::Error;
 use url::Url;
 
@@ -25,45 +27,60 @@ pub enum MQPackageError {
         source: serde_yaml::Error,
     },
 
+    #[error("invalid url")]
+    InvalidURL {
+        #[from]
+        source: url::ParseError,
+    },
+
     #[error("unable to locate a valid directory")]
     NoTargetDirectoryFound,
 }
 
 #[derive(Deserialize, Debug)]
-pub struct Repository {
-    pub repositories: Vec<Url>,
+struct Repository {
+    #[serde(rename = "url")]
+    _url: Url,
 }
 
-#[derive(Debug)]
+impl FromStr for Repository {
+    type Err = MQPackageError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let url = Url::from_str(s).map_err(|source| MQPackageError::InvalidURL { source })?;
+
+        Ok(Repository { _url: url })
+    }
+}
+
+#[serde_with::serde_as]
+#[derive(Deserialize, Debug)]
 pub struct Config {
+    #[serde(skip)]
     target: PathBuf,
-    repositories: Repository,
+
+    #[serde(rename = "repositories")]
+    #[serde_as(as = "Vec<PickFirst<(_, DisplayFromStr)>>")]
+    _repositories: Vec<Repository>,
 }
 
 impl Config {
     pub fn target(&self) -> &Path {
         self.target.as_path()
     }
-
-    pub fn repositories(&self) -> &Repository {
-        &self.repositories
-    }
 }
 
 impl Config {
     pub fn load<P>(path: P) -> Result<Config, MQPackageError>
     where
-        P: Into<PathBuf>,
+        P: AsRef<Path>,
     {
-        let path = path.into();
-        let repofile = File::open(path.join(CONFIG_FILENAME))
+        let target = dunce::canonicalize(path)?;
+        let configfile = File::open(target.join(CONFIG_FILENAME))
             .map_err(|source| MQPackageError::NoConfig { source })?;
-        let repos: Repository = serde_yaml::from_reader(repofile)?;
+        let config: Config = serde_yaml::from_reader(configfile)?;
 
-        Ok(Config {
-            target: path,
-            repositories: repos,
-        })
+        Ok(Config { target, ..config })
     }
 
     pub fn find<P>(path: P) -> Result<Config, MQPackageError>


### PR DESCRIPTION
- Renames our configuration file from ``repositories.yml`` to ``mqpkg.yml``.
- Refactors ``Config`` deserialization to use better patterns.

The ``repositories.yml`` name ended up being kind of annoying to talk about since it also had a ``repositories`` key inside of it. It also meant that if we ever wanted to put any other kind of configuration inside of this file, it starts to get weird (for instance, version pins or something?) because those things are not actually configuring the repositories.

